### PR TITLE
Adjust lint directives for async data functions

### DIFF
--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1117,21 +1117,16 @@ export type SavePromptPayload = Omit<PromptItem, 'id' | 'createdAt' | 'sold' | '
   discount?: number;
 };
 
-export const savePrompt = async (_payload: SavePromptPayload): Promise<{ id: string }>
 // eslint-disable-next-line @typescript-eslint/require-await
- => {
+export const savePrompt = async (_payload: SavePromptPayload): Promise<{ id: string }> => {
   console.info('savePrompt called with payload', _payload);
   return { id: `temp-${Date.now()}` };
 };
 
 export type CheckoutMode = 'one_time' | 'subscription';
 
-export const createCheckoutSession = async (
-  promptId: string,
-  mode: CheckoutMode
-): Promise<{ checkoutUrl: string }>
 // eslint-disable-next-line @typescript-eslint/require-await
- => {
+export const createCheckoutSession = async (promptId: string, mode: CheckoutMode): Promise<{ checkoutUrl: string }> => {
   console.info('createCheckoutSession', { promptId, mode });
   return { checkoutUrl: `https://example.com/checkout?prompt=${promptId}&mode=${mode}` };
 };
@@ -1142,9 +1137,8 @@ export type ReviewPayload = {
   comment: string;
 };
 
-export const submitReviewDraft = async (_payload: ReviewPayload): Promise<{ id: string }>
 // eslint-disable-next-line @typescript-eslint/require-await
- => {
+export const submitReviewDraft = async (_payload: ReviewPayload): Promise<{ id: string }> => {
   console.info('submitReviewDraft', _payload);
   return { id: `review-${Date.now()}` };
 };


### PR DESCRIPTION
## Summary
- move the `require-await` lint disable comments directly above their async exports in `src/lib/data.ts`
- collapse the affected function signatures onto a single line for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1134dc7e08326aaf5ab0a81584b2a